### PR TITLE
Add PowerVS bootstrap Terraform module and examples

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,36 @@
+name: Terraform CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.tf'
+      - '.tflint.hcl'
+      - '.github/workflows/terraform.yml'
+  pull_request:
+    paths:
+      - '**.tf'
+      - '.tflint.hcl'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.6.0
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+      - name: Terraform init
+        run: terraform init -backend=false
+      - name: Terraform validate
+        run: terraform validate
+      - name: Setup tflint
+        uses: terraform-linters/setup-tflint@v1
+        with:
+          tflint_version: latest
+      - name: TFLint
+        run: |
+          tflint --init
+          tflint

--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,5 @@
-# Local .terraform directories
 .terraform/
-
-# .tfstate files
 *.tfstate
 *.tfstate.*
-
-# Crash log files
-crash.log
-crash.*.log
-
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
-*.tfvars
-*.tfvars.json
-
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-# Ignore transient lock info files created by terraform apply
-.terraform.tfstate.lock.info
-
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
-
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
-
-# Ignore CLI configuration files
-.terraformrc
-terraform.rc
+.terraform.lock.hcl
+terraform.tfvars

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,13 @@
+plugin "terraform" {
+  enabled = true
+}
+
+plugin "ibm" {
+  enabled = true
+  source  = "github.com/IBM-Cloud/terraform-tflint-ruleset"
+  version = "0.6.0"
+}
+
+config {
+  module = true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
 # powervs-terraform-bootstrap
-Terraform IaC templates for provisioning AIX and Linux LPARs in IBM Power Virtual Server.
+
+Terraform configuration and module for bootstrapping an [IBM Power Virtual Server](https://www.ibm.com/products/power-virtual-server) lab with one AIX and one Linux LPAR. The configuration creates a resource group, network and two instances while tagging everything for easy clean up.
+
+```mermaid
+graph TD
+    RG[Resource Group]
+    NET[PowerVS Network]
+    AIX[AIX LPAR]
+    LNX[Linux LPAR]
+    RG --> NET
+    RG --> AIX
+    RG --> LNX
+    NET --- AIX
+    NET --- LNX
+```
+
+## Prerequisites
+* IBM Cloud account with an existing PowerVS service instance
+* IBM Cloud API key
+* Terraform ≥ 1.6 and IBM Cloud provider ≥ 1.62.0
+* SSH key uploaded to the PowerVS workspace
+* Optional: Cloud Object Storage/S3 bucket for remote state
+
+## Quickstart
+```bash
+git clone https://github.com/example/powervs-terraform-bootstrap
+cd powervs-terraform-bootstrap
+cp examples/simple/terraform.tfvars.example terraform.tfvars
+terraform init
+terraform apply
+```
+
+## Inputs
+The root module expects the following variables. See `variables.tf` for full details.
+* `ibmcloud_api_key`
+* `region`
+* `zone`
+* `powervs_service_instance_id`
+* `resource_group` (default: `powervs-lab`)
+* `ssh_key_name`
+* `aix_image_name` (default: `AIX 7.3 TLx`)
+* `linux_image_name` (default: `RHEL 9 for Power`)
+* `aix_profile` / `linux_profile` (default: `bx2-4x16`)
+* `owner` (default: `unknown`)
+* `environment` (default: `dev`)
+
+## Outputs
+After `terraform apply` the following outputs are printed:
+* `aix_instance_id` – ID of the AIX LPAR
+* `linux_instance_id` – ID of the Linux LPAR
+* `network_id` – ID of the created network
+* `aix_ip` – IP address of the AIX LPAR if available
+* `linux_ip` – IP address of the Linux LPAR if available
+
+## Remote State
+The configuration uses local state by default. For team environments configure a remote backend such as IBM Cloud Object Storage:
+```hcl
+terraform {
+  backend "s3" {
+    endpoint   = "s3.direct.us-south.cloud-object-storage.appdomain.cloud"
+    bucket     = "<your-bucket>"
+    key        = "powervs-bootstrap/terraform.tfstate"
+    access_key = var.cos_access_key
+    secret_key = var.cos_secret_key
+    skip_region_validation      = true
+    skip_credentials_validation = true
+  }
+}
+```
+
+## Clean up
+Destroy all resources when finished to avoid charges:
+```bash
+terraform destroy
+```
+
+## Cost
+PowerVS instances are billed hourly. The default profiles keep resource usage small, but always destroy the environment when not in use.
+
+## SSH Keys
+`ssh_key_name` must reference an existing key in the PowerVS workspace. To upload a new key:
+```bash
+ibmcloud pi key-create --name my-key --public-key @~/.ssh/id_rsa.pub
+```
+
+## Examples
+* `examples/simple` – minimal single-AIX and Linux lab
+* `examples/ha-cluster` – placeholder for a future HA cluster
+
+## Contributing
+Contributions are welcome! Run `terraform fmt`, `terraform validate` and `tflint` before submitting pull requests.

--- a/examples/ha-cluster/main.tf
+++ b/examples/ha-cluster/main.tf
@@ -1,0 +1,42 @@
+variable "ibmcloud_api_key" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "zone" {
+  type = string
+}
+
+variable "powervs_service_instance_id" {
+  type = string
+}
+
+variable "ssh_key_name" {
+  type = string
+}
+
+variable "owner" {
+  type    = string
+  default = "unknown"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+# Placeholder for a future HA cluster example.
+module "bootstrap" {
+  source = "../.."
+
+  ibmcloud_api_key          = var.ibmcloud_api_key
+  region                    = var.region
+  zone                      = var.zone
+  powervs_service_instance_id = var.powervs_service_instance_id
+  ssh_key_name              = var.ssh_key_name
+  owner                     = var.owner
+  environment               = var.environment
+}

--- a/examples/ha-cluster/terraform.tfvars.example
+++ b/examples/ha-cluster/terraform.tfvars.example
@@ -1,0 +1,7 @@
+ibmcloud_api_key          = "CHANGEME"
+region                    = "us-south"
+zone                      = "dal10"
+powervs_service_instance_id = "xxxx-xxxx"
+ssh_key_name              = "my-ssh-key"
+owner                     = "user"
+environment               = "prod"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,0 +1,41 @@
+variable "ibmcloud_api_key" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "zone" {
+  type = string
+}
+
+variable "powervs_service_instance_id" {
+  type = string
+}
+
+variable "ssh_key_name" {
+  type = string
+}
+
+variable "owner" {
+  type    = string
+  default = "unknown"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+module "bootstrap" {
+  source = "../.."
+
+  ibmcloud_api_key          = var.ibmcloud_api_key
+  region                    = var.region
+  zone                      = var.zone
+  powervs_service_instance_id = var.powervs_service_instance_id
+  ssh_key_name              = var.ssh_key_name
+  owner                     = var.owner
+  environment               = var.environment
+}

--- a/examples/simple/terraform.tfvars.example
+++ b/examples/simple/terraform.tfvars.example
@@ -1,0 +1,7 @@
+ibmcloud_api_key          = "CHANGEME"
+region                    = "us-south"
+zone                      = "dal10"
+powervs_service_instance_id = "xxxx-xxxx"
+ssh_key_name              = "my-ssh-key"
+owner                     = "user"
+environment               = "dev"

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,63 @@
+locals {
+  aix_profile_parts   = split("-", var.aix_profile)
+  aix_proc_mem        = split("x", local.aix_profile_parts[1])
+  aix_processors      = tonumber(local.aix_proc_mem[0])
+  aix_memory_mb       = tonumber(local.aix_proc_mem[1]) * 1024
+
+  linux_profile_parts = split("-", var.linux_profile)
+  linux_proc_mem      = split("x", local.linux_profile_parts[1])
+  linux_processors    = tonumber(local.linux_proc_mem[0])
+  linux_memory_mb     = tonumber(local.linux_proc_mem[1]) * 1024
+
+  base_tags = [
+    "project=powervs-bootstrap",
+    "owner=${var.owner}",
+    "env=${var.environment}"
+  ]
+}
+
+resource "ibm_resource_group" "rg" {
+  name = var.resource_group
+  tags = local.base_tags
+}
+
+data "ibm_pi_key" "ssh" {
+  pi_cloud_instance_id = var.powervs_service_instance_id
+  name                 = var.ssh_key_name
+}
+
+resource "ibm_pi_network" "net" {
+  pi_cloud_instance_id = var.powervs_service_instance_id
+  pi_network_name      = "bootstrap-net"
+  type                 = "pub-vlan"
+  tags                 = local.base_tags
+}
+
+module "aix" {
+  source              = "./modules/powervs-instance"
+  instance_name       = "aix-lpar"
+  image_name          = var.aix_image_name
+  ssh_key_name        = var.ssh_key_name
+  network_id          = ibm_pi_network.net.network_id
+  processors          = local.aix_processors
+  memory_mb           = local.aix_memory_mb
+  sys_type            = "s922"
+  proc_type           = "shared"
+  tags                = concat(local.base_tags, ["os=aix"])
+  service_instance_id = var.powervs_service_instance_id
+}
+
+module "linux" {
+  source              = "./modules/powervs-instance"
+  instance_name       = "linux-lpar"
+  image_name          = var.linux_image_name
+  ssh_key_name        = var.ssh_key_name
+  network_id          = ibm_pi_network.net.network_id
+  processors          = local.linux_processors
+  memory_mb           = local.linux_memory_mb
+  sys_type            = "s922"
+  proc_type           = "shared"
+  tags                = concat(local.base_tags, ["os=linux"])
+  service_instance_id = var.powervs_service_instance_id
+}
+

--- a/modules/powervs-instance/main.tf
+++ b/modules/powervs-instance/main.tf
@@ -1,0 +1,15 @@
+resource "ibm_pi_instance" "vm" {
+  pi_cloud_instance_id = var.service_instance_id
+  pi_instance_name     = var.instance_name
+  pi_image_name        = var.image_name
+  pi_key_names         = [var.ssh_key_name]
+  pi_sys_type          = var.sys_type
+  pi_proc_type         = var.proc_type
+  pi_processors        = var.processors
+  pi_memory            = var.memory_mb
+  pi_networks = [{
+    network_id = var.network_id
+  }]
+  tags = var.tags
+}
+

--- a/modules/powervs-instance/outputs.tf
+++ b/modules/powervs-instance/outputs.tf
@@ -1,0 +1,11 @@
+output "instance_id" {
+  value = ibm_pi_instance.vm.id
+}
+
+output "ip_address" {
+  value = try(ibm_pi_instance.vm.pi_networks[0].ip_address, null)
+}
+
+output "status" {
+  value = ibm_pi_instance.vm.status
+}

--- a/modules/powervs-instance/variables.tf
+++ b/modules/powervs-instance/variables.tf
@@ -1,0 +1,52 @@
+variable "service_instance_id" {
+  type        = string
+  description = "PowerVS service instance ID"
+}
+
+variable "instance_name" {
+  type        = string
+  description = "Instance name"
+}
+
+variable "proc_type" {
+  type        = string
+  description = "Processor type (shared or dedicated)"
+  default     = "shared"
+}
+
+variable "processors" {
+  type        = number
+  description = "Number of processors"
+}
+
+variable "memory_mb" {
+  type        = number
+  description = "Memory in MB"
+}
+
+variable "sys_type" {
+  type        = string
+  description = "System type"
+  default     = "s922"
+}
+
+variable "image_name" {
+  type        = string
+  description = "Image name"
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "SSH key name"
+}
+
+variable "network_id" {
+  type        = string
+  description = "Network ID to attach"
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "List of tags"
+  default     = []
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "aix_instance_id" {
+  value = module.aix.instance_id
+}
+
+output "linux_instance_id" {
+  value = module.linux.instance_id
+}
+
+output "network_id" {
+  value = ibm_pi_network.net.network_id
+}
+
+output "aix_ip" {
+  value = module.aix.ip_address
+}
+
+output "linux_ip" {
+  value = module.linux.ip_address
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,5 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region           = var.region
+  zone             = var.zone
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,87 @@
+variable "ibmcloud_api_key" {
+  type        = string
+  description = "IBM Cloud API key"
+  sensitive   = true
+  validation {
+    condition     = length(var.ibmcloud_api_key) > 0
+    error_message = "IBM Cloud API key must not be empty."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "IBM Cloud region"
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "Region must not be empty."
+  }
+}
+
+variable "zone" {
+  type        = string
+  description = "PowerVS zone"
+  validation {
+    condition     = length(var.zone) > 0
+    error_message = "Zone must not be empty."
+  }
+}
+
+variable "powervs_service_instance_id" {
+  type        = string
+  description = "PowerVS service instance identifier"
+  validation {
+    condition     = length(var.powervs_service_instance_id) > 0
+    error_message = "Service instance ID must not be empty."
+  }
+}
+
+variable "resource_group" {
+  type        = string
+  description = "Resource group name"
+  default     = "powervs-lab"
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Existing SSH key name in the PowerVS workspace"
+  validation {
+    condition     = length(var.ssh_key_name) > 0
+    error_message = "SSH key name must not be empty."
+  }
+}
+
+variable "aix_image_name" {
+  type        = string
+  description = "AIX image name"
+  default     = "AIX 7.3 TLx"
+}
+
+variable "linux_image_name" {
+  type        = string
+  description = "Linux image name"
+  default     = "RHEL 9 for Power"
+}
+
+variable "aix_profile" {
+  type        = string
+  description = "AIX instance profile (processors x memory in GB)"
+  default     = "bx2-4x16"
+}
+
+variable "linux_profile" {
+  type        = string
+  description = "Linux instance profile (processors x memory in GB)"
+  default     = "bx2-4x16"
+}
+
+variable "owner" {
+  type        = string
+  description = "Owner tag"
+  default     = "unknown"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment tag"
+  default     = "dev"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    ibm = {
+      source  = "IBM-Cloud/ibm"
+      version = ">= 1.62.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Bootstrap IBM Power Virtual Server lab with network and AIX/Linux LPAR modules
- Provide reusable `powervs-instance` module and example configurations
- Add CI workflow for fmt, validate, and tflint

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `terraform init -backend=false` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*
- `tflint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08ffa476c83238309450be3c011d3

## Summary by Sourcery

Introduce a Terraform configuration and reusable module for bootstrapping an IBM PowerVS lab with network and AIX/Linux LPARs, supply example deployments, and add CI workflows for code quality checks.

New Features:
- Add root Terraform module to bootstrap an IBM PowerVS lab, including a resource group, network, and AIX and Linux LPAR instances
- Introduce powervs-instance reusable Terraform module for provisioning individual PowerVS instances
- Provide example configurations for simple and HA cluster deployments

Enhancements:
- Add versions.tf and providers.tf to enforce Terraform and IBM provider requirements
- Organize variables, locals, resources, and outputs across dedicated Terraform files

CI:
- Add GitHub Actions workflow for Terraform fmt, init, validate, and TFLint checks
- Add .tflint.hcl configuration enabling Terraform and IBM Cloud linting plugins

Documentation:
- Add comprehensive README with prerequisites, quickstart, inputs, outputs, remote state configuration, cleanup instructions, cost considerations, SSH key usage, and example details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces Terraform setup to bootstrap an IBM PowerVS lab with AIX and Linux instances, including resource group and network creation.
  - Provides a reusable instance module and exposes outputs (instance IDs, IPs, network ID).

- Documentation
  - Expands README with prerequisites, quickstart, inputs/outputs, remote state, cleanup, costs, SSH keys, and examples.
  - Adds “simple” and “HA cluster” example configurations with sample tfvars.

- Chores
  - Adds Terraform CI workflow (format, validate, lint) and TFLint configuration.
  - Updates .gitignore to a minimal Terraform ignore set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->