### PR TITLE
Add PowerVS bootstrap Terraform module and examples

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,19 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.6.0
+      - name: Install Terraform
+        run: |
+          curl -fsSL https://releases.hashicorp.com/terraform/1.6.0/terraform_1.6.0_linux_amd64.zip -o terraform.zip
+          unzip terraform.zip
+          sudo mv terraform /usr/local/bin/terraform
       - name: Terraform fmt
         run: terraform fmt -check -recursive
       - name: Terraform init
         run: terraform init -backend=false
       - name: Terraform validate
         run: terraform validate
-      - name: Setup tflint
-        uses: terraform-linters/setup-tflint@v1
-        with:
-          tflint_version: latest
+      - name: Install TFLint
+        run: |
+          curl -fsSL https://github.com/terraform-linters/tflint/releases/latest/download/tflint_linux_amd64.zip -o tflint.zip
+          unzip tflint.zip
+          sudo mv tflint /usr/local/bin/tflint
       - name: TFLint
         run: |
           tflint --init


### PR DESCRIPTION
## Summary
- Bootstrap IBM Power Virtual Server lab with network and AIX/Linux LPAR modules
- Provide reusable `powervs-instance` module and example configurations
- Add CI workflow for fmt, validate, and tflint without relying on unpinned third-party actions

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `terraform init -backend=false` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*
- `tflint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08ffa476c83238309450be3c011d3

## Summary by Sourcery

Provide a Terraform-based bootstrap solution for IBM Power Virtual Server labs by introducing a root module, a reusable instance module, example configurations, and a CI linting workflow

New Features:
- Add a root powervs-terraform-bootstrap module to provision a resource group, network, and AIX/Linux LPARs
- Introduce a reusable powervs-instance module for provisioning individual PowerVS instances
- Include two example configurations: a simple single-LPAR lab and a placeholder HA cluster

Enhancements:
- Define Terraform settings and infrastructure in variables.tf, providers.tf, versions.tf, main.tf, outputs.tf, and module manifests
- Add .tflint.hcl to enable IBM and core Terraform linting rules

CI:
- Add GitHub Actions workflow to install Terraform and TFLint and run fmt, init, validate, and tflint checks

Documentation:
- Expand README.md with prerequisites, quickstart, inputs/outputs, remote state guidance, cleanup instructions, and architecture diagram