### PR TITLE
Validate network_ids is non-empty

### DIFF
--- a/examples/invalid-empty-network-ids/main.tf
+++ b/examples/invalid-empty-network-ids/main.tf
@@ -1,0 +1,12 @@
+# Intentionally invalid: network_ids is empty
+module "instance" {
+  source = "../../modules/powervs-instance"
+
+  service_instance_id = "dummy"
+  instance_name       = "test"
+  processors          = 1
+  memory_mb           = 1024
+  ssh_key_name        = "key"
+  image_name          = "img"
+  network_ids         = []
+}

--- a/examples/valid-network-ids/main.tf
+++ b/examples/valid-network-ids/main.tf
@@ -1,0 +1,11 @@
+module "instance" {
+  source = "../../modules/powervs-instance"
+
+  service_instance_id = "dummy"
+  instance_name       = "test"
+  processors          = 1
+  memory_mb           = 1024
+  ssh_key_name        = "key"
+  image_name          = "img"
+  network_ids         = ["net-1"]
+}

--- a/modules/powervs-instance/README.md
+++ b/modules/powervs-instance/README.md
@@ -15,7 +15,7 @@ Simple module to create a PowerVS instance with standard tagging.
 | image_name | Image name (exact match) | string | null |
 | image_regex | Image name regex used when image_name is unset | string | null |
 | ssh_key_name | SSH key name | string | n/a |
-| network_ids | Network IDs to attach | list(string) | n/a |
+| network_ids | Network IDs to attach (must be non-empty) | list(string) | n/a |
 | tags | Tags to apply | list(string) | [] |
 
 ### Outputs

--- a/modules/powervs-instance/variables.tf
+++ b/modules/powervs-instance/variables.tf
@@ -70,6 +70,10 @@ variable "ssh_key_name" {
 variable "network_ids" {
   type        = list(string)
   description = "Network IDs to attach"
+  validation {
+    condition     = length(var.network_ids) > 0
+    error_message = "At least one network_id must be provided"
+  }
 }
 
 variable "tags" {

--- a/scripts/test-network-ids.sh
+++ b/scripts/test-network-ids.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "terraform command not found" >&2
+  exit 1
+fi
+
+# Invalid example should fail validation
+terraform -chdir="$ROOT/examples/invalid-empty-network-ids" init -backend=false -input=false -get-plugins=false >/dev/null
+if terraform -chdir="$ROOT/examples/invalid-empty-network-ids" validate >/tmp/invalid.log 2>&1; then
+  echo "Expected validation failure for empty network_ids" >&2
+  cat /tmp/invalid.log >&2
+  exit 1
+else
+  echo "Invalid example failed validation as expected"
+fi
+
+# Valid example should pass validation
+terraform -chdir="$ROOT/examples/valid-network-ids" init -backend=false -input=false -get-plugins=false >/dev/null
+terraform -chdir="$ROOT/examples/valid-network-ids" validate >/tmp/valid.log 2>&1 || {
+  cat /tmp/valid.log >&2
+  exit 1
+}
+
+echo "Valid example passed validation"


### PR DESCRIPTION
## Summary
- fail fast when `network_ids` is empty
- document network requirement and add invalid example
- add test script checking validation failure

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `scripts/test-network-ids.sh` *(fails: terraform command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10bb03320832388858edfa08b0e2c

## Summary by Sourcery

Enforce that the network_ids variable is non-empty and add accompanying documentation, examples, and validation tests.

New Features:
- Add a validation block to the network_ids variable to require at least one entry
- Provide valid and invalid example modules for network_ids in the examples directory

Documentation:
- Update README to document the non-empty requirement for network_ids

Tests:
- Add a test script (scripts/test-network-ids.sh) to verify validation failure for empty network_ids and success for valid cases